### PR TITLE
Compatibility with Google Chrome and non-PC warframe.market 

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,3 +1,7 @@
+if (typeof browser === "undefined") {
+    var browser = chrome;
+}
+
 function requestListener(requestDetails) {
     // Ignore orders only requests
     if (!requestDetails.url.endsWith("orders?include=item")) { return; }

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,9 @@
         "webRequest",
         "activeTab",
         "https://warframe.market/*",
+        "https://switch.warframe.market/*",
+        "https://ps4.warframe.market/*",
+        "https://xbox.warframe.market/*",
         "https://api.warframe.market/v1/items/*"
     ],
 


### PR DESCRIPTION
Simple addition to background.js to make it usable as Google Chrome extension. 
The prior permissions in manifest.json rendered the extension inactive for other platforms that aren't PC since the URLs are different for other platforms. 